### PR TITLE
fix: CVE-2019-10742, removing axios.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,9 @@
 {
   "name": "krcensor-190211",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@types/axios": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@types/axios/-/axios-0.14.0.tgz",
-      "integrity": "sha1-7CMA++fX3d1+udOr+HmZlkyvzkY=",
-      "requires": {
-        "axios": "*"
-      }
-    },
     "@types/caseless": {
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.1.tgz",
@@ -85,15 +77,6 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
     },
-    "axios": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
-      "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
-      "requires": {
-        "follow-redirects": "^1.3.0",
-        "is-buffer": "^1.1.5"
-      }
-    },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
@@ -162,29 +145,6 @@
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
-    "follow-redirects": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.6.1.tgz",
-      "integrity": "sha512-t2JCjbzxQpWvbhts3l6SH1DKzSrx8a+SsaVf4h6bG4kOXUuPYS/kg2Lr4gQSb7eemaHqJkOThF1BGyjlUkO1GQ==",
-      "requires": {
-        "debug": "=3.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        }
-      }
-    },
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -236,11 +196,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-    },
-    "is-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-typedarray": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,6 @@
   "dependencies": {
     "typescript": "^3.3.3",
     "util": "^0.11.1",
-    "axios": "^0.18.0",
-    "@types/axios": "^0.14.0",
     "request": "^2.88.0",
     "@types/request": "^2.48.1",
     "node-cmd": "^3.0.0"
@@ -15,7 +13,6 @@
   "bin": {
     "app": "lib/index.js"
   },
-  "devDependencies": {},
   "scripts": {
     "start": "tsc && node lib/index.js",
     "build": "tsc",

--- a/src/domains/index.ts
+++ b/src/domains/index.ts
@@ -1,7 +1,12 @@
-import axios from 'axios'
+import req from 'request';
 import {domains} from "./offline";
 
 export {domains};
 
-export const getDomains = (): Promise<string[]> =>
-    axios.get('https://asia-northeast1-kr-censorship.cloudfunctions.net/getList').then((data) => data.data);
+export const getDomains = () => {
+    return new Promise<string[]> (
+        (resolve, reject) => {
+            req.get('https://asia-northeast1-kr-censorship.cloudfunctions.net/getList' , {json: true}, (err, res, body:string[]) => resolve(body));
+        });
+}
+


### PR DESCRIPTION
<img width="1001" alt="image" src="https://user-images.githubusercontent.com/27724108/58638381-a36c5c00-832f-11e9-84da-c43d6ba11e77.png">

Currently Axios has vulnerability that can cause program to severely shutdown, Since South Korean government sniffs on national network packet, It might be possible that government might MITM our domain list system and crash our program while it is reading domain names to test.

<img width="810" alt="image" src="https://user-images.githubusercontent.com/27724108/58638548-170e6900-8330-11e9-8853-4cee675192f8.png">

Please check [this](https://nvd.nist.gov/vuln/detail/CVE-2019-10742) for more details about the vulnerability
Plus, This is a 0-day exploit, so I replaced the axios with request. Please check the PR for more details.